### PR TITLE
Test improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
-dist: trusty
 php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0||^8.0",
         "fzaninotto/faker": "^1.6",
-        "php-coveralls/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0",
+        "ext-sqlite3": "*",
+        "ext-pdo_sqlite": "*"
     },
     "require": {
         "divineomega/uxdm": "^3.0.0",

--- a/tests/Unit/EloquentSourceTest.php
+++ b/tests/Unit/EloquentSourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DivineOmega\uxdm\Objects\Tests;
+
 use DivineOmega\uxdm\Objects\Sources\EloquentSource;
 use DivineOmega\uxdm\TestClasses\Eloquent\User;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
# Changed log
- Remove `trusty` dist because all `php-7.x` version is available on `xenial` dist.
And the `xenial` is enabled on Travis CI build by default.
- Define `sqlite3` and `pdo_sqlite` extensions inside `require-dev` block on `composer.json` to remind developers should have these extensions on `phpunit` execution.
- Add `DivineOmega\uxdm\Objects\Tests;` namespace can let test classes load automatically.
- Add a test case for `putDataRows` method test.